### PR TITLE
Ref: #14 - 增加了对SOCKS代理的支持

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,13 +14,13 @@ license = { text = "LGPLv3.0" }
 
 # --- 核心依赖 (CLI版本 和 后端逻辑所必需) ---
 dependencies = [
-    "typer[all]>=0.9.0",  # [all] 会自动包含 rich 等，让CLI体验更好
+    "typer[all]>=0.9.0",
     "requests>=2.30.0",
     "lxml>=5.0.0",
     "keyring>=24.0.0",
     "cryptography>=42.0.0",
     "asyncer==0.0.8",
-    "httpx==0.28.1",
+    "httpx[socks]==0.28.1",
     "anyio==4.11.0",
     "aiofiles==24.1.0",
     "socksio==1.0.0"

--- a/src/Learning_at_ZJU_third_client/CLI/command/assignment.py
+++ b/src/Learning_at_ZJU_third_client/CLI/command/assignment.py
@@ -18,6 +18,7 @@ from datetime import datetime, timezone
 from lxml import html
 from lxml.html import HtmlElement
 
+from ..state import state
 from ...zjuAPI import zju_api
 from ...login.login import ZjuAsyncClient
 
@@ -182,7 +183,7 @@ async def guess_assignment_type(assignment_id: int)->Tuple[bool, bool, bool]:
         cookies = ZjuAsyncClient().load_cookies()
         task = progress.add_task(description="正在猜测任务类型...",total=1)
 
-        async with ZjuAsyncClient(cookies=cookies) as client:
+        async with ZjuAsyncClient(cookies=cookies, trust_env=state.trust_env) as client:
             raw_activity, raw_exam, raw_classroom = await asyncio.gather(*[
                 zju_api.assignmentViewAPIFits(client.session, assignment_id).get_api_data(),
                 zju_api.assignmentExamViewAPIFits(client.session, assignment_id, apis_name=["exam"]).get_api_data(),
@@ -218,7 +219,7 @@ async def view_exam(exam_id: int, type_map: dict, preview: bool):
         cookies = ZjuAsyncClient().load_cookies()
         
         # --- 请求阶段 ---
-        async with ZjuAsyncClient(cookies=cookies) as client:
+        async with ZjuAsyncClient(cookies=cookies, trust_env=state.trust_env) as client:
             raw_exam, raw_exam_submission_list, raw_exam_distribute = await zju_api.assignmentExamViewAPIFits(client.session, exam_id).get_api_data()
         
             if not raw_exam:
@@ -408,7 +409,7 @@ async def view_classroom(classroom_id: int, type_map: dict, preview: bool):
         cookies = ZjuAsyncClient().load_cookies()
         
         # --- 请求阶段 ---
-        async with ZjuAsyncClient(cookies=cookies) as client:
+        async with ZjuAsyncClient(cookies=cookies, trust_env=state.trust_env) as client:
             # 请求classroom与classroom submission数据
             classroom_message, raw_classroom_submissions_list, raw_classroom_subjects_result, raw_classroom_subjects = await zju_api.assignmentClassroomViewAPIFits(client.session, classroom_id).get_api_data()
 
@@ -547,7 +548,7 @@ async def view_activity(activity_id: int, type_map: dict):
 
         cookies = ZjuAsyncClient().load_cookies()
 
-        async with ZjuAsyncClient(cookies=cookies) as client:
+        async with ZjuAsyncClient(cookies=cookies, trust_env=state.trust_env) as client:
             # --- 请求阶段 ---
             # 请求预览数据
             raw_activity_read: dict = (await zju_api.assignmentPreviewAPIFits(client.session, activity_id).post_api_data())[0]
@@ -803,7 +804,7 @@ async def todo_assignment(
         
         cookies = ZjuAsyncClient().load_cookies()
 
-        async with ZjuAsyncClient(cookies=cookies) as client:
+        async with ZjuAsyncClient(cookies=cookies, trust_env=state.trust_env) as client:
             raw_todo_list: dict = (await zju_api.assignmentTodoListAPIFits(client.session).get_api_data())[0]
         progress.advance(task, advance=1)
 
@@ -944,7 +945,7 @@ async def submit_assignment(
     """
     cookies = ZjuAsyncClient().load_cookies()
 
-    async with ZjuAsyncClient(cookies=cookies) as client:
+    async with ZjuAsyncClient(cookies=cookies, trust_env=state.trust_env) as client:
         if await zju_api.assignmentSubmitAPIFits(client.session, activity_id, text, files_id).submit():
             rprint(f"[green]提交成功！[/green]")
         else:

--- a/src/Learning_at_ZJU_third_client/CLI/command/course.py
+++ b/src/Learning_at_ZJU_third_client/CLI/command/course.py
@@ -16,6 +16,7 @@ from rich.console import Group
 from datetime import datetime
 from textwrap import dedent
 
+from ..state import state
 from ...zjuAPI import zju_api
 from ...login.login import ZjuAsyncClient
 # course 命令组
@@ -189,7 +190,7 @@ async def list_courses(
 
         task = progress.add_task(description="拉取课程信息中...", total=1)
 
-        async with ZjuAsyncClient(cookies=cookies) as client:
+        async with ZjuAsyncClient(cookies=cookies, trust_env=state.trust_env) as client:
             if all:
                 pre_results = (await zju_api.coursesListAPIFits(client.session, keyword, 1, 1).get_api_data())[0]
                 amount = pre_results.get("total", 0)
@@ -355,7 +356,7 @@ async def view_syllabus(
         task = progress.add_task(description="获取课程信息中...", total=1)
     
         # --- 加载预备课程信息 ---
-        async with ZjuAsyncClient(cookies=cookies) as client:
+        async with ZjuAsyncClient(cookies=cookies, trust_env=state.trust_env) as client:
             course_messages, raw_course_modules = await zju_api.coursePreviewAPIFits(client.session, course_id).get_api_data()
         
         course_name = course_messages.get("name", "null")
@@ -378,7 +379,7 @@ async def view_syllabus(
                 rprint(f"未找到章节！")
                 return 
 
-            async with ZjuAsyncClient(cookies=cookies) as client:
+            async with ZjuAsyncClient(cookies=cookies, trust_env=state.trust_env) as client:
                 raw_course_activities, raw_course_exams, raw_course_classrooms, raw_course_activities_reads, raw_homework_completeness, raw_exam_completeness = await zju_api.courseViewAPIFits(client.session, course_id).get_api_data()
 
             for module_id, module in modules_list:
@@ -724,7 +725,7 @@ async def view_coursewares(
 
         task = progress.add_task(description="获取课程信息中...", total=2)
 
-        async with ZjuAsyncClient(cookies=cookies) as client:
+        async with ZjuAsyncClient(cookies=cookies, trust_env=state.trust_env) as client:
             if all:
                 pre_raw_coursewares = (await zju_api.coursewaresViewAPIFits(client.session, course_id, 1, 1).get_api_data())[0]
                 page = 1
@@ -856,7 +857,7 @@ async def view_members(
         cookies = ZjuAsyncClient().load_cookies()
         task = progress.add_task(description="请求数据中...", total=2)
 
-        async with ZjuAsyncClient(cookies=cookies) as client:
+        async with ZjuAsyncClient(cookies=cookies, trust_env=state.trust_env) as client:
             raw_course_enrollments = (await zju_api.courseMembersViewAPIFits(client.session, course_id).get_api_data())[0]
 
         progress.update(task, description="渲染任务信息中...", advance=1)

--- a/src/Learning_at_ZJU_third_client/CLI/command/resource.py
+++ b/src/Learning_at_ZJU_third_client/CLI/command/resource.py
@@ -12,6 +12,7 @@ from datetime import datetime
 from pathlib import Path
 from textwrap import dedent
 
+from ..state import state
 from ...zjuAPI import zju_api
 from ...login.login import ZjuAsyncClient
 
@@ -165,7 +166,7 @@ async def list_resources(
 
         cookies = ZjuAsyncClient().load_cookies()
 
-        async with ZjuAsyncClient(cookies=cookies) as client:
+        async with ZjuAsyncClient(cookies=cookies, trust_env=state.trust_env) as client:
             # 如果启用--all，则先获取文件资源总数
             if all:
                 pre_results = (await zju_api.resourcesListAPIFits(client.session, keyword, 1, 1, file_type).get_api_data(False))[0]
@@ -333,7 +334,7 @@ async def upload_resources(
         ) as sub_progress:
             cookies = ZjuAsyncClient().load_cookies()
 
-            async with ZjuAsyncClient(cookies=cookies) as client:
+            async with ZjuAsyncClient(cookies=cookies, trust_env=state.trust_env) as client:
                 files_uploader = zju_api.resourceUploadAPIFits(client.session)
                 
                 for to_upload_file in to_upload_files:
@@ -424,7 +425,7 @@ async def remove_resources(
         if batch:
             task = progress.add_task(description="删除文件中...", total=1)
 
-            async with ZjuAsyncClient(cookies=cookies) as client:
+            async with ZjuAsyncClient(cookies=cookies, trust_env=state.trust_env) as client:
                 file_deleter = zju_api.resourcesRemoveAPIFits(client.session, resources_id=files_id)
             
             if await file_deleter.batch_delete():
@@ -440,7 +441,7 @@ async def remove_resources(
         
         task = progress.add_task(description="删除文件中...", total=files_id_amount)
         
-        async with ZjuAsyncClient(cookies=cookies) as client:
+        async with ZjuAsyncClient(cookies=cookies, trust_env=state.trust_env) as client:
             for file_id in files_id:
                 file_deleter = zju_api.resourcesRemoveAPIFits(client.session, resource_id=file_id)
                 
@@ -522,7 +523,7 @@ async def download_resource(
             ) as sub_progress:
                 cookies = ZjuAsyncClient().load_cookies()
 
-                async with ZjuAsyncClient(cookies=cookies) as client:
+                async with ZjuAsyncClient(cookies=cookies, trust_env=state.trust_env) as client:
                     resources_downloader = zju_api.resourcesDownloadAPIFits(client.session, output_path=dest, resources_id=files_id, basename=basename)
                 
                 # 子任务，跟踪文件下载进度
@@ -564,7 +565,7 @@ async def download_resource(
         ) as sub_progress:
             cookies = ZjuAsyncClient().load_cookies()
 
-            async with ZjuAsyncClient(cookies=cookies) as client:
+            async with ZjuAsyncClient(cookies=cookies, trust_env=state.trust_env) as client:
                 for file_id in files_id:
                     resource_downloader = zju_api.resourcesDownloadAPIFits(client.session, output_path=dest, resource_id=file_id, basename=basename)
                     

--- a/src/Learning_at_ZJU_third_client/CLI/command/rollcall.py
+++ b/src/Learning_at_ZJU_third_client/CLI/command/rollcall.py
@@ -10,6 +10,7 @@ from rich.progress import Progress, SpinnerColumn, TextColumn, BarColumn, TimeEl
 from rich import print as rprint
 from textwrap import dedent
 
+from ..state import state
 from ...zjuAPI import zju_api
 from ...load_config import load_config
 
@@ -63,7 +64,7 @@ async def answer_radar_rollcall(rollcall_id: int, site: str):
     }
     cookies = ZjuAsyncClient().load_cookies()
 
-    async with ZjuAsyncClient(cookies=cookies) as client:
+    async with ZjuAsyncClient(cookies=cookies, trust_env=state.trust_env) as client:
         raw_rollcall_answer_list = await zju_api.rollcallAnswerRadarAPIFits(
             client.session, rollcall_id, rollcall_data
         ).put_api_data()
@@ -139,7 +140,7 @@ async def answer_number_rollcall(rollcall_id: int, number_code: str|None):
     device_id = generate_device_id()
     cookies = ZjuAsyncClient().load_cookies()
 
-    async with ZjuAsyncClient(cookies=cookies) as client:
+    async with ZjuAsyncClient(cookies=cookies, trust_env=state.trust_env) as client:
         if number_code:
             rollcall_data = {
                 "deviceId": device_id,
@@ -236,7 +237,7 @@ async def list_rollcall():
         task = progress.add_task(description="请求数据中...", total=2)
         cookies = ZjuAsyncClient().load_cookies()
 
-        async with ZjuAsyncClient(cookies=cookies) as client:
+        async with ZjuAsyncClient(cookies=cookies, trust_env=state.trust_env) as client:
             raw_rollcalls_list = (await zju_api.rollcallListAPIFits(client.session).get_api_data())[0]
         
         rollcalls_list: List[dict] = raw_rollcalls_list.get("rollcalls", [])

--- a/src/Learning_at_ZJU_third_client/CLI/state.py
+++ b/src/Learning_at_ZJU_third_client/CLI/state.py
@@ -2,8 +2,10 @@ from ..login.login import ZjuClient, ZjuAsyncClient
 
 # 维护全局登录状态
 class State:
+    """状态类，用于在 LAZY CLI 内共享全局状态
+    """
     def __init__(self):
         # self.client: ZjuClient = None
-        self.client: ZjuAsyncClient = None
+        self.trust_env: bool = True
 
 state = State()

--- a/src/Learning_at_ZJU_third_client/login/login.py
+++ b/src/Learning_at_ZJU_third_client/login/login.py
@@ -45,7 +45,12 @@ def generate_encryption_key()->bytes:
 
 # 异步架构Client类
 class ZjuAsyncClient:
-    def __init__(self, headers=None, cookies=None):
+    def __init__(
+        self, 
+        headers   = None, 
+        cookies   = None,
+        trust_env = True
+    ):
         """初始化会话
 
         Parameters
@@ -55,7 +60,13 @@ class ZjuAsyncClient:
         """
         # 初始化会话    
         logger.info("初始化会话中...")
-        self.session = httpx.AsyncClient()
+        
+        if trust_env:
+            logger.info(f"启用全局代理")
+        else:
+            logger.info(f"全局代理关闭")
+
+        self.session = httpx.AsyncClient(trust_env=trust_env)
 
         if headers is None:
             headers = {


### PR DESCRIPTION
修改了 pyproject.toml，使得 httpx 支持SOCKS代理。

增加了全局选项 '--no-proxy'，允许指定 lazy 忽视代理。

修改了 login/login.py 下的 ZjuAsyncClient 使其支持代理配置。

修改了各子命令初始化会话的方式，使其支持代理配置。

将 CLI/state.py 修改为全局状态共享管理器，以后开发更多功能。